### PR TITLE
Add --ignore option to Bundler Audit Command

### DIFF
--- a/lib/lois/cli.rb
+++ b/lib/lois/cli.rb
@@ -31,14 +31,13 @@ module Lois
                   default: 'circleci',
                   aliases: '-c',
                   desc: 'CI to load env vars from.'
-    method_option :ignore
+    method_option :ignore,
                   desc: 'Ignore a specific CVE vulnerability'
-                  aliases: '\--ignore'
     def bundler_audit
       puts 'Checking bundler-audit'
       configure(options)
 
-      ignore = "--ignore #{options[:ignore]}"
+      ignore = " --ignore #{options[:ignore]}"
       command = 'bundle-audit check --verbose --update'
       command += ignore if options[:ignore]
       output = `#{command}`

--- a/lib/lois/cli.rb
+++ b/lib/lois/cli.rb
@@ -31,11 +31,17 @@ module Lois
                   default: 'circleci',
                   aliases: '-c',
                   desc: 'CI to load env vars from.'
+    method_option :ignore
+                  desc: 'Ignore a specific CVE vulnerability'
+                  aliases: '\--ignore'
     def bundler_audit
       puts 'Checking bundler-audit'
       configure(options)
 
-      output = `bundle-audit check --verbose --update`
+      ignore = "--ignore #{options[:ignore]}"
+      command = 'bundle-audit check --verbose --update'
+      command += ignore if options[:ignore]
+      output = `#{command}`
       result = $CHILD_STATUS
       File.write('lois/bundler-audit.log', output)
       puts output

--- a/lib/lois/version.rb
+++ b/lib/lois/version.rb
@@ -1,3 +1,3 @@
 module Lois
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.1.7'.freeze
 end


### PR DESCRIPTION
Introduces the `--ignore` flag which already exists in the bundler-audit gem itself. This allows for lois to execute it's bundler-audit command like so `lois bundler-audit --ignore CVE-2015-9284` which will ignore the given CVE.